### PR TITLE
configuration using CELERY_BEAT_SCHEDULE broke with Entry override

### DIFF
--- a/django_celery_beat_rrule/model_entry.py
+++ b/django_celery_beat_rrule/model_entry.py
@@ -5,7 +5,10 @@ from django_celery_beat.models import (
     IntervalSchedule,
     SolarSchedule,
     ClockedSchedule,
+    PeriodicTask,
 )
+from .models import RrulePeriodicTask
+from .rruleschedule import rruleschedule
 from django_celery_beat.schedulers import ModelEntry
 
 from django_celery_beat_rrule.models import RruleSchedule
@@ -20,3 +23,12 @@ class RruleModelEntry(ModelEntry):
         (clocked, ClockedSchedule, "clocked"),
         (rruleschedule, RruleSchedule, "rrule"),
     )
+
+    @classmethod
+    def from_entry(cls, name, app=None, **entry):
+        if isinstance(entry.get('schedule', None), rruleschedule):
+            obj, created = RrulePeriodicTask._default_manager.update_or_create(
+                name=name, defaults=cls._unpack_fields(**entry),
+            )
+            return cls(obj, app=app)
+        return ModelEntry.from_entry(name, app=app, **entry)


### PR DESCRIPTION
Non-rrule entries in CELERY_BEAT_SCHEDULE resulted in attempts to create base PeriodicTasks from RrulePeriodicTask fields.

Cannot add entry xxx to database schedule: FieldError ("Invalid field name(s) for model PeriodicTask: 'rrule'...

Repro -
create beat rule in your django settings. This should result in an error on beat startup.

CELERY_BEAT_SCHEDULE = {
    'auto-checkout': {
        'task': 'actions.tasks.auto_checkout',
        'schedule': crontab(minute=5),
    },
}